### PR TITLE
Remove duplicate code to import MSS

### DIFF
--- a/vidgear/gears/screengear.py
+++ b/vidgear/gears/screengear.py
@@ -77,17 +77,9 @@ class ScreenGear:
 		#intialize threaded queue mode
 		self.threaded_queue_mode = True
 		try:
-			# try import necessary system specific mss library
-			import platform			
-			if platform.system() == 'Linux':
-				from mss.linux import MSS as mss
-			elif platform.system() == 'Windows':
-				from mss.windows import MSS as mss
-			elif platform.system() == 'Darwin':
-				from mss.darwin import MSS as mss
-			else:
-				from mss import mss
-			#import mss error handler
+			# import mss factory
+			from mss import mss
+			# import mss error handler
 			from mss.exception import ScreenShotError
 		except ImportError as error:
 			# otherwise raise import error


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description

In fact, the old code was a copy of the `mss.mss()` factory.

### Requirements / Checklist

<!--- Put an `x` in all the boxes that apply(important): -->

- [x] Read the [Contributing Guidelines](https://github.com/abhiTronix/vidgear/blob/master/contributing.md)
- [x] Read the [FAQ](https://github.com/abhiTronix/vidgear/wiki/FAQ-&-Troubleshooting)
- [x] Comprehended the [Wiki Documentation](https://github.com/abhiTronix/vidgear/wiki#vidgear)
- [x] Updated the source-code documentation accordingly (if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #38.

### Context
<!--- Why is this change required? What problem does it solve? -->

This is a cleanup patch to prevent double work in case the OS is not handled.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply(important): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if available):
None.



